### PR TITLE
Enhancement: Use ergebnis/phpstan-rules instead of localheinz/phpstan-rules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "phpstan/phpstan": "^0.11.19",
         "phpstan/phpstan-phpunit": "^0.11.2",
         "thecodingmachine/phpstan-strict-rules": "^0.11.2",
-        "localheinz/phpstan-rules": "^0.13.0"
+        "ergebnis/phpstan-rules": "^0.14.0"
     },
     "license": "MIT",
     "authors": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,12 +4,12 @@ includes:
     - vendor/thecodingmachine/phpstan-strict-rules/phpstan-strict-rules.neon
 
 rules:
-    - Localheinz\PHPStan\Rules\Expressions\NoEvalRule
-    - Localheinz\PHPStan\Rules\Files\DeclareStrictTypesRule
+    - Ergebnis\PHPStan\Rules\Expressions\NoEvalRule
+    - Ergebnis\PHPStan\Rules\Files\DeclareStrictTypesRule
 
 services:
     -
-        class: Localheinz\PHPStan\Rules\Classes\FinalRule
+        class: Ergebnis\PHPStan\Rules\Classes\FinalRule
         arguments:
             allowAbstractClasses: true
             classesNotRequiredToBeAbstractOrFinal: []


### PR DESCRIPTION
This PR

* [x] uses `ergebnis/phpstan-rules` instead of `localheinz/phpstan-rules`

💁‍♂ For reference, see https://localheinz.com/blog/2019/12/10/from-localheinz-to-ergebnis/.